### PR TITLE
Add support for widevine v0 parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "mp4pssh",
-  "version": "0.0.2",
+  "name": "@re/mp4pssh",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2858,7 +2858,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2879,12 +2880,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2899,17 +2902,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3026,7 +3032,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3038,6 +3045,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3052,6 +3060,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3059,12 +3068,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3083,6 +3094,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3163,7 +3175,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3175,6 +3188,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3260,7 +3274,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3296,6 +3311,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3315,6 +3331,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3358,12 +3375,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@re/mp4pssh",
   "version": "2.0.0",
   "description": "TypeScript MP4 PSSH Parser",
-  "main": "./src/index.ts",
+  "main": "./dist/mp4pssh.js",
   "types": "./dist/types/index.d.ts",
   "author": "RealEyes Media <info@realeyes.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@re/mp4pssh",
-  "version": "0.0.2",
+  "version": "2.0.0",
   "description": "TypeScript MP4 PSSH Parser",
-  "main": "./dist/mp4pssh.js",
+  "main": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "author": "RealEyes Media <info@realeyes.com>",
   "scripts": {

--- a/src/consts/system-ids.const.ts
+++ b/src/consts/system-ids.const.ts
@@ -1,7 +1,6 @@
 import { SystemNames } from "../enums/system-names.enum";
 
 export const SystemIds = {
-  [SystemNames.WIDEVINE_V0]: "1077EFECC0B24D02ACE33C1E52E2FB4B",
-  [SystemNames.WIDEVINE_V1]: "edef8ba979d64acea3c827dcd51d21ed",
+  [SystemNames.WIDEVINE]: "edef8ba979d64acea3c827dcd51d21ed",
   [SystemNames.PLAYREADY]: "9a04f07998404286ab92e65be0885f95",
 };

--- a/src/consts/system-ids.const.ts
+++ b/src/consts/system-ids.const.ts
@@ -1,4 +1,7 @@
+import { SystemNames } from "../enums/system-names.enum";
+
 export const SystemIds = {
-    WIDEVINE: 'edef8ba979d64acea3c827dcd51d21ed',
-    PLAYREADY: '9a04f07998404286ab92e65be0885f95'
-}
+  [SystemNames.WIDEVINE_V0]: "1077EFECC0B24D02ACE33C1E52E2FB4B",
+  [SystemNames.WIDEVINE_V1]: "edef8ba979d64acea3c827dcd51d21ed",
+  [SystemNames.PLAYREADY]: "9a04f07998404286ab92e65be0885f95",
+};

--- a/src/enums/system-names.enum.ts
+++ b/src/enums/system-names.enum.ts
@@ -1,5 +1,4 @@
 export enum SystemNames {
-  WIDEVINE_V0 = "WIDEVINE_V0",
-  WIDEVINE_V1 = "WIDEVINE_V1",
+  WIDEVINE = "WIDEVINE",
   PLAYREADY = "PLAYREADY",
 }

--- a/src/enums/system-names.enum.ts
+++ b/src/enums/system-names.enum.ts
@@ -1,0 +1,5 @@
+export enum SystemNames {
+  WIDEVINE_V0 = "WIDEVINE_V0",
+  WIDEVINE_V1 = "WIDEVINE_V1",
+  PLAYREADY = "PLAYREADY",
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-export * from "./enums/system-names.enum";
 export * from "./pssh-parser/pssh-parser";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export * from './pssh-parser/pssh-parser';
+export * from "./enums/system-names.enum";
+export * from "./pssh-parser/pssh-parser";

--- a/src/models/pssh.model.ts
+++ b/src/models/pssh.model.ts
@@ -1,9 +1,6 @@
-import { SystemNames } from "../enums/system-names.enum";
-
 export interface PSSH {
   version: number;
   systemId: string;
-  system: SystemNames;
   dataSize: number;
   data: Uint8Array;
   keyData?: PSSHKeyData;

--- a/src/models/pssh.model.ts
+++ b/src/models/pssh.model.ts
@@ -1,8 +1,14 @@
+import { SystemNames } from "../enums/system-names.enum";
+
 export interface PSSH {
-    version: number;
-    systemId: string;
-    kidCount?: number;
-    kids?: string[];
-    dataSize: number;
-    data: Uint8Array;
+  version: number;
+  systemId: string;
+  system: SystemNames;
+  dataSize: number;
+  data: Uint8Array;
+  keyData?: PSSHKeyData;
+}
+export interface PSSHKeyData {
+  kidCount: number;
+  kids: string[];
 }

--- a/src/pssh-parser/pssh-parser.ts
+++ b/src/pssh-parser/pssh-parser.ts
@@ -21,29 +21,21 @@ export class PSSHParser {
 
     offset += 16; // SystemId length
 
-    let system: SystemNames = SystemNames.WIDEVINE_V0;
     let keyData: PSSHKeyData | undefined = undefined;
 
     switch (systemId) {
-      case SystemIds[SystemNames.WIDEVINE_V0]:
-        system = SystemNames.WIDEVINE_V0;
+      case SystemIds[SystemNames.WIDEVINE]:
+        if (version === 1) {
+          const v1KeyData = this.parseWidevineV1KeyData(view, offset);
 
-        break;
+          offset += 4 + 16 * v1KeyData.kidCount;
 
-      case SystemIds[SystemNames.WIDEVINE_V1]:
-        system = SystemNames.WIDEVINE_V1;
-
-        const v1KeyData = this.parseWidevineV1KeyData(view, offset);
-
-        offset += 4 + 16 * v1KeyData.kidCount;
-
-        keyData = v1KeyData;
+          keyData = v1KeyData;
+        }
 
         break;
 
       case SystemIds[SystemNames.PLAYREADY]:
-        system = SystemNames.PLAYREADY;
-
         break;
     }
 
@@ -57,7 +49,6 @@ export class PSSHParser {
       data,
       dataSize,
       systemId,
-      system,
       version,
       keyData,
     };


### PR DESCRIPTION
@gregrealeyes This is the fix for using Widevine v0 PSSH parsing. I changed several things, including the shape of the returned parsed PSSH object, so I bumped this to v2.0.0.

Let me know if you have any concerns and we can address them in other PRs, as this PR is time-sensitive